### PR TITLE
Fix README.md, Apply config.italic_* to theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ Note: set the configurations **BEFORE** you load the color scheme
 
 | Option                     | Default   | Description              |
 | -------------------------- | --------- | ------------------------ |
-| minimal_italic_comments  | `true`    | Make comments italic     |
-| minimal_italic_keywords  | `false`   | Make keywords italic     |
-| minimal_italic_booleans  | `false`   | Make booleans italic     |
-| minimal_italic_functions | `false`   | Make functions italic    |
-| minimal_italic_variables | `false`   | Make variables italic    |
-| minimal_transparent_background      | `false`   | Disable background color |
+| oh_lucy_italic_comments  | `true`    | Make comments italic     |
+| oh_lucy_italic_keywords  | `true`   | Make keywords italic     |
+| oh_lucy_italic_booleans  | `false`   | Make booleans italic     |
+| oh_lucy_italic_functions | `false`   | Make functions italic    |
+| oh_lucy_italic_variables | `true`   | Make variables italic    |
+| oh_lucy_transparent_background      | `false`   | Disable background color |
 
 
 ```lua

--- a/lua/oh-lucy/config.lua
+++ b/lua/oh-lucy/config.lua
@@ -17,6 +17,7 @@ config = {
   transparent_background = opt('transparent_background', false),
   italic_comments = opt('italic_keywords', true) and 'italic' or 'NONE',
   italic_keywords = opt('italic_keywords', true) and 'italic' or 'NONE',
+  italic_booleans = opt('italic_booleans', false) and 'italic' or 'NONE',
   italic_functions = opt('italic_function', false) and 'italic' or 'NONE',
   italic_variables = opt('italic_variables', true) and 'italic' or 'NONE',
 }

--- a/lua/oh-lucy/theme.lua
+++ b/lua/oh-lucy/theme.lua
@@ -16,7 +16,7 @@ M.base = {
     -----------------------------------------
     --        Editors settings
     -----------------------------------------
-    Boolean = { fg = colors.orange },
+    Boolean = { fg = colors.orange, style = config.italic_booleans },
 
     Character    = { fg = colors.yellow },
     ColorColumn  = { bg = colors.black1 },
@@ -52,14 +52,14 @@ M.base = {
     FloatBorder = { fg = colors.gray2, bg = "NONE" },
     FoldColumn  = { fg = colors.line_fg },
     Folded      = { fg = colors.white, bg = colors.gray },
-    Function    = { fg = colors.green_func },
+    Function    = { fg = colors.green_func, style = config.italic_functions },
 
     Identifier = { fg = colors.white1 },
     Ignore     = { fg = colors.gray_punc },
     IncSearch  = { fg = colors.bg, bg = colors.orange },
     Include    = { fg = colors.blue_type },
 
-    Keyword = { fg = colors.red_key_w },
+    Keyword = { fg = colors.red_key_w, style = config.italic_keywords },
 
     Label  = { fg = colors.red_key_w },
     LineNr = { fg = colors.line_fg, bg = colors.line_bg },
@@ -125,7 +125,7 @@ M.base = {
     Type         = { fg = colors.blue_type },
     Typedef      = { fg = colors.blue_type },
 
-    Variable  = { fg = colors.white },
+    Variable  = { fg = colors.white, style = config.italic_variables },
     VertSplit = { fg = colors.vsplit_bg },
     Visual    = { fg = "NONE", bg = colors.visual_select_bg, style = 'bold' },
     VisualNOS = { fg = colors.selection_fg, bg = colors.selection_bg },
@@ -416,11 +416,11 @@ M.plugins = {
     -----------------------------------------
     pythonConditional = { fg = colors.red_key_w },
     pythonException   = { fg = colors.pink },
-    pythonFunction    = { fg = colors.green_func },
+    pythonFunction    = { fg = colors.green_func, config.italic_functions },
     pythonInclude     = { fg = colors.red_key_w },
     pythonOperator    = { fg = colors.red_key_w },
     pythonStatement   = { fg = colors.white },
-    pythonBoolean     = { fg = colors.white },
+    pythonBoolean     = { fg = colors.white, style = config.italic_booleans },
     -----------------------------------------
 
 
@@ -551,7 +551,7 @@ M.plugins = {
     -----------------------------------------
     TSAnnotation         = { fg = colors.yellow },
     TSAttribute          = { fg = colors.white },
-    TSBoolean            = { fg = colors.pink },
+    TSBoolean            = { fg = colors.pink, style = config.italic_booleans },
     TSCharacter          = { fg = colors.yellow },
     TSCharacterSpecial   = { fg = colors.yellow },
     TSComment            = { fg = colors.comment, style = 'italic' },
@@ -567,11 +567,11 @@ M.plugins = {
     TSFloat              = { fg = colors.pink },
     TSFuncBuiltin        = { fg = colors.green_func },
     TSFuncMacro          = { fg = colors.blue_type },
-    TSFunction           = { fg = colors.green_func },
+    TSFunction           = { fg = colors.green_func, style = config.italic_functions },
     TSInclude            = { fg = colors.red_key_w },
-    TSKeyword            = { fg = colors.red_key_w },
-    TSKeywordFunction    = { fg = colors.red_key_w },
-    TSKeywordOperator    = { fg = colors.red_key_w },
+    TSKeyword            = { fg = colors.red_key_w, style = config.italic_keywords },
+    TSKeywordFunction    = { fg = colors.red_key_w, style = config.italic_keywords },
+    TSKeywordOperator    = { fg = colors.red_key_w, style = config.italic_keywords },
     TSKeywordReturn      = { fg = colors.red_key_w },
     TSNone               = { fg = colors.orange },
     TSLabel              = { fg = colors.pink },
@@ -604,7 +604,7 @@ M.plugins = {
     TSTypeQualifier      = { fg = colors.red_key_w },
     TSURI                = { fg = colors.yellow, style = 'underline' },
     TSUnderline          = { style = 'underline' },
-    TSVariable           = { fg = colors.white },
+    TSVariable           = { fg = colors.white, style = config.italic_variables },
     TSVariableBuiltin    = { fg = colors.pink },
     TSDefine             = { fg = colors.red_key_w },
     -----------------------------------------


### PR DESCRIPTION
* Fix wrong `config prefix` (inside of config options table) in [README.md](https://github.com/Yazeed1s/oh-lucy.nvim/blob/main/README.md) 
* Add `italic_booleans` to config.lua (Closes #4)
* Apply `config.italic_*` to theme
  e.g `Keyword = { fg = colors.red_key_w, style = config.italic_keywords }`
  