### PR TITLE
fix theme selection issue

### DIFF
--- a/lua/oh-lucy/theme.lua
+++ b/lua/oh-lucy/theme.lua
@@ -1,5 +1,5 @@
-local colors = require 'oh-lucy-evening.colors'
-local config = require 'oh-lucy-evening.config'
+local colors = require 'oh-lucy.colors'
+local config = require 'oh-lucy.config'
 
 local M = {}
 


### PR DESCRIPTION
**Issue:**
Whether you used `colorscheme oh-lucy` or `colorscheme oh-lucy-evening`, it didn't matter. The _evening_ version of the theme was always used. This could be related to issue #11. 

**Changes:**
Updated `lua/oh-lucy/theme.lua` to properly select the non-evening version of the theme.