### PR TITLE
fix: LineNr and SignColumn for transparent bg

### DIFF
--- a/lua/oh-lucy/theme.lua
+++ b/lua/oh-lucy/theme.lua
@@ -62,7 +62,7 @@ M.base = {
     Keyword = { fg = colors.red_key_w },
 
     Label  = { fg = colors.red_key_w },
-    LineNr = { fg = colors.line_fg, bg = colors.line_bg },
+    LineNr = { fg = colors.line_fg, bg = config.transparent_background and 'NONE' or colors.line_bg },
 
     Macro         = { fg = colors.blue_type },
     MatchParen    = { fg = colors.white1, bg = colors.black },
@@ -94,7 +94,7 @@ M.base = {
     Repeat = { fg = colors.red_key_w },
 
     Search              = { fg = colors.line_fg, bg = colors.orange },
-    SignColumn          = { bg = colors.line_bg },
+    SignColumn          = { bg = config.transparent_background and 'NONE' or colors.line_bg },
     Special             = { fg = colors.gray_punc },
     SpecialChar         = { fg = colors.yellow },
     SpecialComment      = { fg = colors.pink },


### PR DESCRIPTION
**Issue:**
When setting background to transparent, the LineNr and SignColumn still use the background color. 

**Example:**

Old:
<img width="116" alt="Screenshot 2024-06-19 at 21 00 53" src="https://github.com/Yazeed1s/oh-lucy.nvim/assets/82053045/790903a8-109c-46bb-accf-45322676dc7c">

New:
<img width="116" alt="Screenshot 2024-06-19 at 21 01 35" src="https://github.com/Yazeed1s/oh-lucy.nvim/assets/82053045/74fea4ba-e3bc-4161-9ca9-28e3d5e8554d">

**Changes:**
Updated `lua/oh-lucy/theme.lua` to match the background.