### PR TITLE
Add support for rainbow-delimiters plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ If any of the colors does not syntax-highlight your langauge satisfactorily, ple
 - [Telescope](https://github.com/nvim-telescope/telescope.nvim)
 - [NvimTree](https://github.com/kyazdani42/nvim-tree.lua)
 - [Barbar](https://github.com/romgrk/barbar.nvim)
+- [Rainbow delimiters](https://github.com/hiphish/rainbow-delimiters.nvim)
 - and more...
 
 ## 👇 Requirements

--- a/lua/oh-lucy-evening/theme.lua
+++ b/lua/oh-lucy-evening/theme.lua
@@ -172,6 +172,16 @@ M.base = {
 
 
 M.plugins = {
+    -----------------------------------------
+    --   Rainbow delimiters: github.com/hiphish/rainbow-delimiters.nvim
+    -----------------------------------------
+    RainbowDelimiterRed = { fg = colors.red_key_w },
+    RainbowDelimiterOrange = { fg = colors.orange },
+    RainbowDelimiterYellow = { fg = colors.yellow },
+    RainbowDelimiterGreen = { fg = colors.green },
+    RainbowDelimiterBlue = { fg = colors.blue_type },
+    RainbowDelimiterViolet = { fg = colors.pink },
+    RainbowDelimiterCyan = { fg = colors.boolean },
 
     -----------------------------------------
     --   Buffer:

--- a/lua/oh-lucy/theme.lua
+++ b/lua/oh-lucy/theme.lua
@@ -172,6 +172,16 @@ M.base = {
 
 
 M.plugins = {
+    -----------------------------------------
+    --   Rainbow delimiters: github.com/hiphish/rainbow-delimiters.nvim
+    -----------------------------------------
+    RainbowDelimiterRed = { fg = colors.red_key_w },
+    RainbowDelimiterOrange = { fg = colors.orange },
+    RainbowDelimiterYellow = { fg = colors.yellow },
+    RainbowDelimiterGreen = { fg = colors.green },
+    RainbowDelimiterBlue = { fg = colors.blue_type },
+    RainbowDelimiterViolet = { fg = colors.pink },
+    RainbowDelimiterCyan = { fg = colors.boolean },
 
     -----------------------------------------
     --   Buffer:
@@ -404,6 +414,10 @@ M.plugins = {
     LspDiagnosticsVirtualTextHint        = { fg = colors.gray2 }, -- Deprecated
     LspDiagnosticsVirtualTextInformation = { fg = colors.yellow }, -- Deprecated
     LspDiagnosticsUnderlineInformation   = { style = 'underline' }, -- Deprecated
+    -----------------------------------------
+
+    -----------------------------------------
+    -- Rainbow delimiters:   github.comhiphish/rainbow-delimiters.nvim/
     -----------------------------------------
 
 


### PR DESCRIPTION
### Before: 
![image](https://github.com/user-attachments/assets/fc6d0570-8cdc-4de2-9a57-1ac8120e3a84)

### After: 
![image](https://github.com/user-attachments/assets/fcf9cb69-61b1-4e30-a8c0-fae8735f7aa6)
