### PR TITLE
Fix colors_name not being set

### DIFF
--- a/lua/oh-lucy-evening/init.lua
+++ b/lua/oh-lucy-evening/init.lua
@@ -2,6 +2,7 @@ local util          = require 'oh-lucy-evening.util'
 local theme         = require 'oh-lucy-evening.theme'
 
 vim.o.background    = 'dark'
-vim.g.colors_name   = 'oh-lucy-evening'
 
 util.load(theme)
+
+vim.g.colors_name   = 'oh-lucy-evening'

--- a/lua/oh-lucy/init.lua
+++ b/lua/oh-lucy/init.lua
@@ -2,6 +2,7 @@ local util          = require 'oh-lucy.util'
 local theme         = require 'oh-lucy.theme'
 
 vim.o.background    = 'dark'
-vim.g.colors_name   = 'oh-lucy'
 
 util.load(theme)
+
+vim.g.colors_name   = 'oh-lucy'


### PR DESCRIPTION
I think this is more reasonable and works as any colorscheme should. after it's applied `vim.g.colors_name` is set